### PR TITLE
Initialization of working variable in mo_agg_topo_cosmo

### DIFF
--- a/src/mo_agg_topo_cosmo.f90
+++ b/src/mo_agg_topo_cosmo.f90
@@ -332,6 +332,7 @@ MODULE mo_agg_topo_cosmo
      hh_target_scale  = 0.0
      hh2_target_scale = 0.0
      stdh_z0          = 0.0
+     hh_sqr_diff      = 0.0
    ENDIF
 !> *mes
    IF (lsso_param) THEN


### PR DESCRIPTION
Roughness length calculation is incorrect without this initialization.  