### PR TITLE
Add missing variable id call in globcover subroutine

### DIFF
--- a/src/mo_agg_globcover.f90
+++ b/src/mo_agg_globcover.f90
@@ -639,6 +639,8 @@ CONTAINS
 
               IF (.NOT. l_opn_gc_file(tile)) THEN
                 CALL check_netcdf(nf90_open(TRIM(globcover_file(tile)),NF90_NOWRITE, ncid_globcover(tile)), __FILE__, __LINE__)
+                CALL check_netcdf(nf90_inq_varid(ncid_globcover(tile),TRIM(varname), varid_gc(tile)))
+                l_opn_gc_file(tile) = .TRUE.
               ENDIF
 
               CALL check_netcdf(nf90_get_var(ncid_globcover(tile), varid_gc(tile),  &


### PR DESCRIPTION
There is a missing netcdf get_varid call when the GLOBCOVER landuse data set is used with more than one tile.  I ported the relevant code in from EXTPAR 4.0.  