### PR TITLE
Change CDI submodule URL to a pulic one

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "bundled/cdi"]
 	path = bundled/cdi
-	url = git@gitlab.dkrz.de:mpim-sw/libcdi.git
+	url = https://gitlab.dkrz.de/mpim-sw/libcdi.git


### PR DESCRIPTION
The submodule for libcdi points to a non-public URL in the DKRZ GitLab. Thus the checkout fails for those of us that don't have access to it.

Don't know if this is the proper solution, but in the meantime, this may be good enough.

Thx for the tip @m214089 
