### PR TITLE
Fix calculation of runtime in runcontrol_functions.sh

### DIFF
--- a/test/testsuite/bin/runcontrol_functions.sh
+++ b/test/testsuite/bin/runcontrol_functions.sh
@@ -10,7 +10,7 @@ run_sequential()
     rc=$?
     printf "   Return code: %i\n" $rc >> ${logfile}
     end=$(date +%s.%N)
-    (( runtime = end - start ))
+    runtime=$(echo ${end} - ${start} | bc)
     if [[ $rc -eq "0" ]]; then
 
         echo "   SUCCESS ${1%% *}" >> ${logfile}


### PR DESCRIPTION
The variable `runtime` in test/testsuite/bin/runcontrol_functions.sh is computed as follows:

```
#!/bin/ksh
...
    start=$(date +%s.%N)
...
    end=$(date +%s.%N)
   (( runtime = end - start ))
```

This fails with this error: 

```
./extpar_atmcirc_0.08_665x490.sh[439]: 1606676800.039278205: unexpected '.' 
```

Instead, use `bc` to compute the difference between the two floats:

```
    runtime=$(echo ${end} - ${start} | bc)
```
