### PR TITLE
Remove gpu partition from levante runscript

### DIFF
--- a/templates/submit.levante.sh
+++ b/templates/submit.levante.sh
@@ -5,7 +5,7 @@
 #SBATCH --cpus-per-task=12 
 #SBATCH --output="job.out"
 #SBATCH --time=02:00:00
-#SBATCH --partition=gpu,shared,compute
+#SBATCH --partition=shared,compute
 #SBATCH --account=@ACCOUNT@
 
 export OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK


### PR DESCRIPTION
otherwise you get the following error:

```
sbatch.bin: error: using the multi-partition string 'gpu,shared,compute' is not allowed for gpu and interactive partition
sbatch.bin: error: Batch job submission failed: Unspecified error
```