### PR TITLE
increase memory and source modules.env

### DIFF
--- a/templates/submit.levante.sh
+++ b/templates/submit.levante.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #SBATCH --job-name="extpar"
-#SBATCH --mem=36G
+#SBATCH --mem=50G
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=12 
 #SBATCH --output="job.out"
@@ -13,6 +13,8 @@ export PYTHONPATH=@PYTHONPATH@:$PYTHONPATH
 
 logfile=extpar.log
 rm $logfile
+
+if [ -e modules.env ]; then source modules.env; fi
 source runcontrol_functions.sh
 
 for exe in @EXTPAR_EXECUTABLES@


### PR DESCRIPTION
this sets the requested memory to 50GB in the runscript and sources the `modules.env` file (if existent). Otherwise one is missing the errors when the `modules.env` file has not been loaded when submitting the job