### PR TITLE
OpenMP parallelization for radtopo option

### DIFF
--- a/configure.rcl.gcc
+++ b/configure.rcl.gcc
@@ -56,7 +56,7 @@ LDFLAGS=""
 
 LIBS=""
 
-BUILD_LIBS="-L/hpc/sw/hdf5/1.10.5/x86/intel/lib -L/hpc/sw/netcdf4/4.7.3/x86/intel/lib -lnetcdf -lnetcdff -lhdf5_hl -lhdf5"
+BUILD_LIBS="-L/hpc/sw/hdf5/1.10.5/x86/gnu-9.1.0/lib -L/hpc/sw/netcdf4/4.7.3/x86/gnu-9.1.0/lib -lnetcdf -lnetcdff -lhdf5_hl -lhdf5"
 
 EXTRA_CONFIG_ARGS="--enable-rpaths "
 EXTRA_CONFIG_ARGS+="--enable-openmp "

--- a/src/mo_lradtopo.f90
+++ b/src/mo_lradtopo.f90
@@ -500,6 +500,7 @@ MODULE mo_lradtopo
     ENDDO
 
     ! loop over all cells
+!$OMP PARALLEL DO PRIVATE(rlat_cell,rlon_cell,nh,start_cell_id,target_co_rad,target_co_deg,dz,nearest_cell_id,rates)
     DO i=1,tg%ie 
 
       !get_coordinates of cell in radians
@@ -597,6 +598,7 @@ MODULE mo_lradtopo
       z_missing_data(i,:) = z_missing_data(i,:) / REAL(size_radius * refine_factor)
 
     ENDDO ! tg%ie
+!$OMP END PARALLEL DO
 
     ! set all horizon angles to 0 for missingness-fraction above max_missing
     DO nh=1, nhori


### PR DESCRIPTION
The calculation of the radtopo parameters (topographic shading mask) is annoyingly slow for larger domains. Therefore, the main loop of this routine has been OpenMP parallelized, speeding up the calculation by almost a factor of 10 with 32 threads. 

Moreover, the path entries for netcdf and hdf5 have been corrected for DWD's rcl in order to avoid a dependency from gcc to shared libraries of the intel compiler.