### PR TITLE
Small change in replacing the missing values of Modis cdnc

### DIFF
--- a/python/extpar_cdnc_to_buffer.py
+++ b/python/extpar_cdnc_to_buffer.py
@@ -131,7 +131,7 @@ utils.launch_shell('cdo', lock, '-f',
                    tg.cdo_sellonlat(), raw_data_cdnc, cdnc_cdo)
 
 # set missing values to a minimal value
-utils.launch_shell('cdo', '-f', 'nc4', '-P', omp, lock, f'setmisstoc,30',
+utils.launch_shell('cdo', '-f', 'nc4', '-P', omp, lock, f'setmisstoc,-1',
                    cdnc_cdo, cdnc_tmp)
 
 #--------------------------------------------------------------------------


### PR DESCRIPTION
After discussing with my colleague, we think that replacing the missing values in MODIS input cdnc data with an unique value -1 is better than setting those to a minimal value of 30cm-3. The reason for this is we want to test some values of cdnc in the region where MODIS does not provide data. By having -1 in the extpar data, we can easily replace -1 with some other values in ICON Code.

This is a small change, I hope it would not be a problem. 

Best regards,
Trang