### PR TITLE
Split dockerfiles

### DIFF
--- a/.github/workflows/build-base-container.yml
+++ b/.github/workflows/build-base-container.yml
@@ -1,9 +1,13 @@
-name: Build Docker Container
+name: Build Base image
 
-on: [push]
+on:
+  push:
+    paths:
+      - '.github/workflows/build-base-container.yml'
+      - 'Dockerfile.base'
 
 jobs:
-  build:
+  build-base:
     runs-on: ubuntu-latest
 
     steps:
@@ -31,18 +35,8 @@ jobs:
           outputs: type=oci,dest=extpar_base_image.tar
           platforms: linux/amd64,linux/arm64
 
-      - name: Build extpar image
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          file: ./Dockerfile.extpar
-          push: false
-          tags: c2sm/extpar:latest
-          outputs: type=oci,dest=extpar_image.tar
-          platforms: linux/amd64,linux/arm64
-
       - name: Upload Docker image as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v2
         with:
-          name: extpar_image.tar
-          path: extpar_image.tar
+          name: extpar_base_image.tar
+          path: extpar_base_image.tar

--- a/.github/workflows/build-base-container.yml
+++ b/.github/workflows/build-base-container.yml
@@ -32,11 +32,4 @@ jobs:
           file: ./Dockerfile.base
           push: false
           tags: c2sm/extpar-base:latest
-          outputs: type=oci,dest=extpar_base_image.tar
           platforms: linux/amd64,linux/arm64
-
-      - name: Upload Docker image as artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: extpar_base_image.tar
-          path: extpar_base_image.tar

--- a/.github/workflows/build-base-container.yml
+++ b/.github/workflows/build-base-container.yml
@@ -32,4 +32,4 @@ jobs:
           file: ./Dockerfile.base
           push: false
           tags: c2sm/extpar-base:latest
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -22,7 +22,6 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build base image
-        if: github.event_name == 'push' && contains(github.event.head_commit.message, 'Dockerfile.base')
         uses: docker/build-push-action@v2
         with:
           context: .

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -21,15 +21,6 @@ jobs:
           username: c2sm
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build base image
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          file: ./Dockerfile.base
-          push: false
-          tags: c2sm/extpar-base:latest
-          platforms: linux/amd64,linux/arm64
-
       - name: Build extpar image
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile.base
-          push: false
+          push: True
           tags: c2sm/extpar-base:latest
           outputs: type=oci,dest=extpar_base_image.tar
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -28,4 +28,4 @@ jobs:
           file: ./Dockerfile.extpar
           push: false
           tags: c2sm/extpar:latest
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -21,11 +21,22 @@ jobs:
           username: c2sm
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build Docker image
+      - name: Build base image
+        if: github.event_name == 'push' && contains(github.event.head_commit.message, 'Dockerfile.base')
         uses: docker/build-push-action@v2
         with:
           context: .
-          file: ./Dockerfile
+          file: ./Dockerfile.base
+          push: false
+          tags: c2sm/extpar-base:latest
+          outputs: type=oci,dest=extpar_base_image.tar
+          platforms: linux/amd64,linux/arm64
+
+      - name: Build extpar image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile.extpar
           push: false
           tags: c2sm/extpar:latest
           outputs: type=oci,dest=extpar_image.tar

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -28,7 +28,6 @@ jobs:
           file: ./Dockerfile.base
           push: false
           tags: c2sm/extpar-base:latest
-          outputs: type=oci,dest=extpar_base_image.tar
           platforms: linux/amd64,linux/arm64
 
       - name: Build extpar image
@@ -38,11 +37,4 @@ jobs:
           file: ./Dockerfile.extpar
           push: false
           tags: c2sm/extpar:latest
-          outputs: type=oci,dest=extpar_image.tar
           platforms: linux/amd64,linux/arm64
-
-      - name: Upload Docker image as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: extpar_image.tar
-          path: extpar_image.tar

--- a/.github/workflows/upload_to_dockerhub.yml
+++ b/.github/workflows/upload_to_dockerhub.yml
@@ -1,4 +1,4 @@
-name: Build Docker Image and Upload as Release Asset
+name: Build Base and Extpar images and upload to Docker Hub
 
 on:
   push:
@@ -6,7 +6,7 @@ on:
       - '*'
 
 jobs:
-  build_and_release:
+  build_and_upload:
     runs-on: ubuntu-latest
 
     steps:
@@ -24,14 +24,20 @@ jobs:
           username: c2sm
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build and Save Docker image
-        id: build_docker_image
+      - name: Build base image
         uses: docker/build-push-action@v2
         with:
           context: .
-          file: ./Dockerfile
+          file: ./Dockerfile.base
+          push: true
+          tags: c2sm/extpar-base:latest
+          platforms: linux/amd64,linux/arm64
+
+      - name: Build extpar image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile.extpar
           push: true
           tags: c2sm/extpar:${{ github.ref_name }}
           platforms: linux/amd64,linux/arm64
-          asset_name: extpar_image.tar
-          asset_content_type: application/x-tar

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,37 @@
+# Use the latest Debian image
+FROM debian:bookworm-slim
+
+# Set environment variables to avoid interactive prompts during package installation
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Needed for testsuite to pick correct path to input-data
+ENV HOSTNAME=docker
+
+# Update the package list and install required packages
+RUN apt-get update && \
+    apt-get install -y \
+    git \
+    vim \
+    gcc \
+    gfortran \
+    libnetcdf-dev \
+    libnetcdff-dev \
+    libsz2 \
+    libomp-dev \
+    python3 \
+    python3-pip \
+    python3-venv  \
+    bc \
+    cdo \
+    wget \
+    && apt-get clean
+
+# Verify installations
+RUN gcc --version && \
+    gfortran --version && \
+    git --version && \
+    vim --version && \
+    nc-config --version && \
+    nf-config --version
+
+CMD ["/bin/bash"]

--- a/Dockerfile.extpar
+++ b/Dockerfile.extpar
@@ -1,4 +1,3 @@
-# Use the latest Ubuntu image
 FROM c2sm/extpar-base:latest
 
 # set pipefail for make command

--- a/Dockerfile.extpar
+++ b/Dockerfile.extpar
@@ -1,38 +1,5 @@
 # Use the latest Ubuntu image
-FROM debian:bookworm-slim
-
-# Set environment variables to avoid interactive prompts during package installation
-ENV DEBIAN_FRONTEND=noninteractive
-
-# Needed for testsuite to pick correct path to input-data
-ENV HOSTNAME=docker
-
-# Update the package list and install required packages
-RUN apt-get update && \
-    apt-get install -y \
-    git \
-    vim \
-    gcc \
-    gfortran \
-    libnetcdf-dev \
-    libnetcdff-dev \
-    libsz2 \
-    libomp-dev \
-    python3 \
-    python3-pip \
-    python3-venv  \
-    bc \
-    cdo \
-    wget \
-    && apt-get clean
-
-# Verify installations
-RUN gcc --version && \
-    gfortran --version && \
-    git --version && \
-    vim --version && \
-    nc-config --version && \
-    nf-config --version
+FROM c2sm/extpar-base:latest
 
 # set pipefail for make command
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/Dockerfile.extpar
+++ b/Dockerfile.extpar
@@ -14,7 +14,7 @@ COPY . /workspace/
 RUN /workspace/configure.docker.gcc
 
 # Build extpar
-RUN cd /workspace && make -j 8  2>&1 | tee -a compile.log
+RUN cd /workspace && make -j 2  2>&1 | tee -a compile.log
 
 # Create a virtual environment and install the package
 RUN python3 -m venv /workspace/venv && \

--- a/test/jenkins/build.sh
+++ b/test/jenkins/build.sh
@@ -33,6 +33,7 @@ case "$(hostname)" in
 
     # container build run at CO2
     *co2*)
-        run_command podman build -t extpar:$ghprbPullId -f Dockerfile .
+        run_command podman build -t extpar-base:latest -f Dockerfile.base .
+        run_command podman build -t extpar:$ghprbPullId -f Dockerfile.extpar .
         ;;
 esac


### PR DESCRIPTION
In order to speed-up build times the Dockerfile is split into a base-image and an extpar-image.

Also drop builds for each push for arm64, it takes too long.
For each release still build and push arm64.

Minor adjustements in the ci needed for that.