### PR TITLE
Correct grid shift in topography data

### DIFF
--- a/src/mo_topo_data.f90
+++ b/src/mo_topo_data.f90
@@ -278,10 +278,19 @@ MODULE mo_topo_data
      ! reads in the last latitude value of tile i
      CALL check_netcdf(nf90_close(ncid))
      ! the netcdf file is closed again
-     tiles_lon_min(i) = REAL(NINT(tiles_lon_min(i) - half_gridp)) !< half of a grid point must be
-     tiles_lon_max(i) = REAL(NINT(tiles_lon_max(i) + half_gridp)) !< added, as the ASTER/GLOBE/MERIT data
-     tiles_lat_min(i) = REAL(NINT(tiles_lat_min(i) + half_gridp)) !< is located at the pixel center
-     tiles_lat_max(i) = REAL(NINT(tiles_lat_max(i) - half_gridp))
+     SELECT CASE (itopo_type)
+       ! compute domain extent of tiles (coordinates refer to domain edges) from pixel center coordinates
+       CASE(topo_aster, topo_gl) ! edges of raw data tiles align with integer coordinates
+         tiles_lon_min(i) = REAL(NINT(tiles_lon_min(i) - half_gridp))
+         tiles_lon_max(i) = REAL(NINT(tiles_lon_max(i) + half_gridp))
+         tiles_lat_min(i) = REAL(NINT(tiles_lat_min(i) - half_gridp))
+         tiles_lat_max(i) = REAL(NINT(tiles_lat_max(i) + half_gridp))
+       CASE(topo_merit) ! edges of raw data tiles do not align with integer coordinates
+         tiles_lon_min(i) = REAL(tiles_lon_min(i) - half_gridp)
+         tiles_lon_max(i) = REAL(tiles_lon_max(i) + half_gridp)
+         tiles_lat_min(i) = REAL(tiles_lat_min(i) - half_gridp)
+         tiles_lat_max(i) = REAL(tiles_lat_max(i) + half_gridp)
+     END SELECT
    END DO
 
    SELECT CASE(itopo_type)


### PR DESCRIPTION
- Latitudinal/longitudinal grid shift by half a grid cell for MERIT removed. In contrast to GLOBE/ASTER, MERIT is defined on a grid where cell centers coincide with integer longitude/latitude values, which causes an erroneous shift by `NINT(...)`
- The addition/subtraction of half a grid cell (latitude) to compute the boundary was corrected (the effect of the decreasingly ordered latitude values is already accounted for a couple of lines above when the coordinates are read in)
