### PR TITLE
Pass lat-lon points to BallTree instead of lon-lat

### DIFF
--- a/.github/workflows/upload_to_dockerhub.yml
+++ b/.github/workflows/upload_to_dockerhub.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - fix-art-haversine-args
     tags:
       - '*'
 

--- a/.github/workflows/upload_to_dockerhub.yml
+++ b/.github/workflows/upload_to_dockerhub.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - fix-art-haversine-args
     tags:
       - '*'
 

--- a/python/extpar_art_to_buffer.py
+++ b/python/extpar_art_to_buffer.py
@@ -28,8 +28,8 @@ except ImportError:
     from namelist import input_art as iart
 
 
-def get_neighbor_index(index, hlon, hlat, idxs, ones, balltree):
-    points = np.column_stack((hlon, hlat[index] * ones))
+def get_neighbor_index(index, hlat, hlon, idxs, ones, balltree):
+    points = np.column_stack((hlat, hlon[index] * ones))
     idxs[index, :] = balltree.query(points, k=1)[1].squeeze()
 
 
@@ -200,14 +200,14 @@ logging.info(
 )
 logging.info("")
 
-lon_lat_array = np.column_stack((lons.ravel(), lats.ravel()))
-balltree = BallTree(lon_lat_array, metric="haversine", leaf_size=3)
+lat_lon_array = np.column_stack((lats.ravel(), lons.ravel()))
+balltree = BallTree(lat_lon_array, metric="haversine", leaf_size=3)
 
-ones = np.ones((raw_lon.size))
+ones = np.ones((raw_lat.size))
 
-nrows = np.arange(raw_lat.size)
+nrows = np.arange(raw_lon.size)
 Parallel(n_jobs=omp, max_nbytes='100M', mmap_mode='w+')(delayed(
-    get_neighbor_index)(i, raw_lon, raw_lat, neighbor_ids, ones, balltree)
+    get_neighbor_index)(i, raw_lat, raw_lon, neighbor_ids, ones, balltree)
                                                         for i in tqdm(nrows))
 
 # --------------------------------------------------------------------------

--- a/python/extpar_art_to_buffer.py
+++ b/python/extpar_art_to_buffer.py
@@ -29,7 +29,7 @@ except ImportError:
 
 
 def get_neighbor_index(index, hlat, hlon, idxs, ones, balltree):
-    points = np.column_stack((hlat, hlon[index] * ones))
+    points = np.column_stack((hlat[index] * ones, hlon))
     idxs[index, :] = balltree.query(points, k=1)[1].squeeze()
 
 
@@ -203,9 +203,9 @@ logging.info("")
 lat_lon_array = np.column_stack((lats.ravel(), lons.ravel()))
 balltree = BallTree(lat_lon_array, metric="haversine", leaf_size=3)
 
-ones = np.ones((raw_lat.size))
+ones = np.ones((raw_lon.size))
 
-nrows = np.arange(raw_lon.size)
+nrows = np.arange(raw_lat.size)
 Parallel(n_jobs=omp, max_nbytes='100M', mmap_mode='w+')(delayed(
     get_neighbor_index)(i, raw_lat, raw_lon, neighbor_ids, ones, balltree)
                                                         for i in tqdm(nrows))

--- a/test/testsuite/data/get_data.sh
+++ b/test/testsuite/data/get_data.sh
@@ -14,23 +14,23 @@ fi
 # mch
 test -d mch || exit 1
 cd mch/c7_globe
-wget --quiet 'ftp://iacftp.ethz.ch/pub_read/stelliom/external_parameter_mch_c7_PR435.nc'
+wget --quiet 'ftp://iacftp.ethz.ch/pub_read/stelliom/external_parameter_mch_c7_PR439.nc'
 cd -
 
 test -d mch || exit 1
 cd mch/c1_aster
-wget --quiet 'ftp://iacftp.ethz.ch/pub_read/stelliom/external_parameter_mch_c1_PR435.nc'
+wget --quiet 'ftp://iacftp.ethz.ch/pub_read/stelliom/external_parameter_mch_c1_PR439.nc'
 cd -
 
 # clm
 test -d clm || exit 1
 cd clm/12km_globe
-wget --quiet 'ftp://iacftp.ethz.ch/pub_read/stelliom/external_parameter_12km_globe_PR435.nc'
+wget --quiet 'ftp://iacftp.ethz.ch/pub_read/stelliom/external_parameter_12km_globe_PR439.nc'
 cd -
 
 cd clm/ecoclimap_sg
 wget --quiet 'ftp://iacftp.ethz.ch/pub_read/stelliom/icon_grid_bolivia.nc'
-wget --quiet 'ftp://iacftp.ethz.ch/pub_read/stelliom/external_parameter_icon_eco_PR435.nc'
+wget --quiet 'ftp://iacftp.ethz.ch/pub_read/stelliom/external_parameter_icon_eco_PR439.nc'
 cd -
 
 # dwd
@@ -38,14 +38,14 @@ test -d dwd || exit 1
 
 cd dwd/icon_d2
 wget --quiet 'ftp://iacftp.ethz.ch/pub_read/stelliom/icon_grid_DOM01.nc'
-wget --quiet 'ftp://iacftp.ethz.ch/pub_read/stelliom/external_parameter_icon_d2_PR435.nc'
+wget --quiet 'ftp://iacftp.ethz.ch/pub_read/stelliom/external_parameter_icon_d2_PR439.nc'
 cd -
 
 cd dwd/icon_ecci
 wget --quiet 'ftp://iacftp.ethz.ch/pub_read/stelliom/icon_grid_bolivia.nc'
 wget --quiet 'ftp://iacftp.ethz.ch/pub_read/stelliom/clim_t2m_icon_ecci.nc'
 wget --quiet 'ftp://iacftp.ethz.ch/pub_read/stelliom/clim_tsea_icon_ecci.nc'
-wget --quiet 'ftp://iacftp.ethz.ch/pub_read/stelliom/external_parameter_icon_ecci_PR435.nc'
+wget --quiet 'ftp://iacftp.ethz.ch/pub_read/stelliom/external_parameter_icon_ecci_PR439.nc'
 cd -
 
 # mpim
@@ -54,14 +54,14 @@ cd mpim/icon_r2b4
 wget --quiet 'http://icon-downloads.mpimet.mpg.de/grids/public/mpim/0013/icon_grid_0013_R02B04_G.nc'
 wget --quiet 'ftp://iacftp.ethz.ch/pub_read/stelliom/clim_t2m_icon_r2b4.nc'
 wget --quiet 'ftp://iacftp.ethz.ch/pub_read/stelliom/clim_tsea_icon_r2b4.nc'
-wget --quiet 'ftp://iacftp.ethz.ch/pub_read/stelliom/external_parameter_icon_mpim_PR435.nc'
+wget --quiet 'ftp://iacftp.ethz.ch/pub_read/stelliom/external_parameter_icon_mpim_PR439.nc'
 cd -
 
 # ecmwf
 test -d ecmwf || exit 1
 cd ecmwf/corine_icon
 wget --quiet 'ftp://iacftp.ethz.ch/pub_read/stelliom/corine/icon_grid_0099_R19B10.nc'
-wget --quiet 'ftp://iacftp.ethz.ch/pub_read/stelliom/corine/external_parameter_icon_corine_PR435.nc'
+wget --quiet 'ftp://iacftp.ethz.ch/pub_read/stelliom/corine/external_parameter_icon_corine_PR439.nc'
 wget --quiet 'ftp://iacftp.ethz.ch/pub_read/stelliom/corine/clim_tsea_corine.nc'
 wget --quiet 'ftp://iacftp.ethz.ch/pub_read/stelliom/corine/clim_t2m_corine.nc'
 cd -


### PR DESCRIPTION
## Description

The haversine distance metric for *sklearn*'s BallTree requires the points to be passed in lat-lon format (see [docs](https://scikit-learn.org/stable/modules/generated/sklearn.metrics.pairwise.haversine_distances.html#haversine-distances)). We were passing those in lon-lat format, causing large errors (smoothing/"dripping" artifacts) around 90E and 90W longitude lines.

<img width="6462" height="3106" alt="fr_loam_haversine" src="https://github.com/user-attachments/assets/fe4b0f96-a9c0-4a3d-b1ff-89532230b519" />

Passing the points in lat-lon format seems to solve the issue.

<img width="6462" height="3106" alt="Image" src="https://github.com/user-attachments/assets/6ca76014-353a-45ba-b67e-67680562252d" />

## Workflow for merging PRs

Please read these instructions carefully and follow the steps below before requesting a review by the maintainers. This way we can ensure a smoother review process and your changes will be merged sooner.

Additionally, if this is the first PR you open in EXTPAR make sure to read the [*"Information for EXTPAR Developers"*](https://c2sm.github.io/extpar/development/) section in the documentation.

### Checklist

- [x] Provide a detailed description of your changes in the "Description" section above.
- [x] If you implemented a new feature:
  - [x] Document it in the correct Markdown file(s) under the [`docs/`](https://github.com/C2SM/extpar/tree/master/docs) directory.
  - [x] [Add a new test](https://c2sm.github.io/extpar/testing/#add-a-new-test) or make sure your changes are already tested.
- [x] Your code follows the [style guidelines](https://c2sm.github.io/extpar/development/#coding-rules-and-best-practices).
- [x] Your changes only touch the files/lines relevant for you.
- [x] All four required checks pass (see [*"Testing and debugging"*](#testing-and-debugging) for more details).
- [x] No conflicts with the base branch.

If all the points above are satisfied you can ask for a review by selecting `stelliom` as a reviewer.

For any questions please ping `@stelliom` on this PR.

### Testing and debugging

The most important test for PRs is the one labeled *"EXTPAR Testsuite on Jenkins"*. This checks that the results of all testcases (described by the namelists in [`test/testsuite/data`](https://github.com/C2SM/extpar/tree/master/test/testsuite/data)) did not change compared to the references.

You can launch the testsuite by writing `launch jenkins` as a comment in the PR that you want to test. Once completed, the result of the testsuite will be shown on the PR (failure or success).

If you need more details on the testsuite results (e.g., if you are trying to debug an error or you are simply unsure why the tests fail) you can launch the testsuite with `launch jenkins(debug)`. This will run the tests as usual, but, once completed, you will be given a URL (via a comment on the PR) to access the logfiles and namelists of all tests that were run.
