### PR TITLE
Interpolation algorithm for ERA5 data to ICON grid changed to bilinear

### DIFF
--- a/python/extpar_era_to_buffer.py
+++ b/python/extpar_era_to_buffer.py
@@ -144,7 +144,7 @@ logging.info('============= CDO: remap to target grid ========')
 logging.info('')
 
 # calculate weights
-utils.launch_shell('cdo', '-f', 'nc4', lock, '-P', omp, f'genycon,{grid}',
+utils.launch_shell('cdo', '-f', 'nc4', lock, '-P', omp, f'genbil,{grid}',
                    tg.cdo_sellonlat(), raw_data_sst, weights)
 
 # regrid SST

--- a/python/extpar_era_to_buffer.py
+++ b/python/extpar_era_to_buffer.py
@@ -144,13 +144,13 @@ logging.info('============= CDO: remap to target grid ========')
 logging.info('')
 
 # calculate weights
-era_5_resolution = 31.0 # approximate ERA5 resolution [km]
+era_5_resolution = 31.0  # approximate ERA5 resolution [km]
 if (tg.resolution < era_5_resolution):
     utils.launch_shell('cdo', '-f', 'nc4', lock, '-P', omp, f'genbil,{grid}',
-                    tg.cdo_sellonlat(), raw_data_sst, weights)
+                       tg.cdo_sellonlat(), raw_data_sst, weights)
 else:
     utils.launch_shell('cdo', '-f', 'nc4', lock, '-P', omp, f'genycon,{grid}',
-                    tg.cdo_sellonlat(), raw_data_sst, weights)
+                       tg.cdo_sellonlat(), raw_data_sst, weights)
 
 # regrid SST
 utils.launch_shell('cdo', '-f', 'nc4', lock, '-P', omp,

--- a/python/extpar_era_to_buffer.py
+++ b/python/extpar_era_to_buffer.py
@@ -144,8 +144,13 @@ logging.info('============= CDO: remap to target grid ========')
 logging.info('')
 
 # calculate weights
-utils.launch_shell('cdo', '-f', 'nc4', lock, '-P', omp, f'genbil,{grid}',
-                   tg.cdo_sellonlat(), raw_data_sst, weights)
+era_5_resolution = 31.0 # approximate ERA5 resolution [km]
+if (tg.resolution < era_5_resolution):
+    utils.launch_shell('cdo', '-f', 'nc4', lock, '-P', omp, f'genbil,{grid}',
+                    tg.cdo_sellonlat(), raw_data_sst, weights)
+else:
+    utils.launch_shell('cdo', '-f', 'nc4', lock, '-P', omp, f'genycon,{grid}',
+                    tg.cdo_sellonlat(), raw_data_sst, weights)
 
 # regrid SST
 utils.launch_shell('cdo', '-f', 'nc4', lock, '-P', omp,

--- a/python/lib/grid_def.py
+++ b/python/lib/grid_def.py
@@ -72,8 +72,8 @@ class CosmoGrid:
 
         self.lats, self.lons = self.latlon_cosmo_to_latlon_regular()
 
-        self.resolution = ((2.0 * np.pi * 6.371229 * 10 ** 3)
-                           / 360.0 * self.dlon) # [km]
+        self.resolution = (
+            (2.0 * np.pi * 6.371229 * 10**3) / 360.0 * self.dlon)  # [km]
 
     def create_grid_description(self, name):
         '''
@@ -266,8 +266,8 @@ class IconGrid:
         self.vlons = np.rad2deg(self.grid.variables["vlon"][:])
         self.vlats = np.rad2deg(self.grid.variables["vlat"][:])
 
-        self.resolution = (5050.0 / (self.grid.grid_root
-                                     * 2 ** self.grid.grid_level)) # [km]
+        self.resolution = (
+            5050.0 / (self.grid.grid_root * 2**self.grid.grid_level))  # [km]
 
     def cdo_sellonlat(self, dlon=1.0, dlat=1.0):
         '''

--- a/python/lib/grid_def.py
+++ b/python/lib/grid_def.py
@@ -72,6 +72,9 @@ class CosmoGrid:
 
         self.lats, self.lons = self.latlon_cosmo_to_latlon_regular()
 
+        self.resolution = ((2.0 * np.pi * 6.371229 * 10 ** 3)
+                           / 360.0 * self.dlon) # [km]
+
     def create_grid_description(self, name):
         '''
         write grid description required for cdo
@@ -262,6 +265,9 @@ class IconGrid:
 
         self.vlons = np.rad2deg(self.grid.variables["vlon"][:])
         self.vlats = np.rad2deg(self.grid.variables["vlat"][:])
+
+        self.resolution = (5050.0 / (self.grid.grid_root
+                                     * 2 ** self.grid.grid_level)) # [km]
 
     def cdo_sellonlat(self, dlon=1.0, dlat=1.0):
         '''


### PR DESCRIPTION
## Description

When using the Tegen aerosol climatology in ICON, a horizontal reference pressure field is required for the vertical distribution of the aerosol optical depths (AOD). With the option` itype_vegetation_cycle >= 2`, the reference pressure is computed with the ERA5 orography (resolution: ~30 km). For high-resolution ICON runs, the resolution of this orography is more similar to the very coarse one from the Tegen data.
So far, the ERA5 orography was remapped to the ICON grid with a first-order conservative scheme. For an ICON simulation at 1km, this leads to a very "blocky" orography, and the artefacts are finally also visible in surface downward direct shortwave radiation (ASWDIR_S) through the computation of reference pressure and vertically resolved AODs:

![map_exp_3h_cpu_01_ind_time_5_ASWDIR_S](https://github.com/user-attachments/assets/43cbf2ec-a0d9-4503-87b5-445a756cd7cb)

I discussed this issue with Daniel Rieger and Günther Zängl (DWD). Günther suggested to change the interpolation algorithm for ERA5 orography. I implemented this by changing the interpolation algorithm for ERA5 orography (and other ERA5 variables) to bilinear interpolation. This resolves the block-artefacts in ASWDIR_S:

![map_exp_3h_gpu_21_ind_time_5_ASWDIR_S](https://github.com/user-attachments/assets/3c7b6587-ecc7-4f0b-a78e-979bc21a2e7c)

## Workflow for merging PRs

Please read these instructions carefully and follow the steps below before requesting a review by the maintainers. This way we can ensure a smoother review process and your changes will be merged sooner.

Additionally, if this is the first PR you open in EXTPAR make sure to read the [*"Information for EXTPAR Developers"*](https://c2sm.github.io/extpar/development/) section in the documentation.

### Checklist

- [x] Provide a detailed description of your changes in the "Description" section above.
- [ ] If you implemented a new feature:
  - [ ] Document it in the correct Markdown file(s) under the [`docs/`](https://github.com/C2SM/extpar/tree/master/docs) directory.
  - [ ] [Add a new test](https://c2sm.github.io/extpar/testing/#add-a-new-test) or make sure your changes are already tested.
- [x] Your code follows the [style guidelines](https://c2sm.github.io/extpar/development/#coding-rules-and-best-practices).
- [x] Your changes only touch the files/lines relevant for you.
- [ ] All four required checks pass (see [*"Testing and debugging"*](#testing-and-debugging) for more details).
- [x] No conflicts with the base branch.

If all the points above are satisfied you can ask for a review by selecting `stelliom` as a reviewer.

For any questions please ping `@stelliom` on this PR.

### Testing and debugging

The most important test for PRs is the one labeled *"EXTPAR Testsuite on Jenkins"*. This checks that the results of all testcases (described by the namelists in [`test/testsuite/data`](https://github.com/C2SM/extpar/tree/master/test/testsuite/data)) did not change compared to the references.

You can launch the testsuite by writing `launch jenkins` as a comment in the PR that you want to test. Once completed, the result of the testsuite will be shown on the PR (failure or success).

If you need more details on the testsuite results (e.g., if you are trying to debug an error or you are simply unsure why the tests fail) you can launch the testsuite with `launch jenkins(debug)`. This will run the tests as usual, but, once completed, you will be given a URL (via a comment on the PR) to access the logfiles and namelists of all tests that were run.
