### PR TITLE
Switch to debian:trixie-slim for base container

### DIFF
--- a/.github/workflows/upload_to_dockerhub.yml
+++ b/.github/workflows/upload_to_dockerhub.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - bump-debian-version
     tags:
       - '*'
 

--- a/.github/workflows/upload_to_dockerhub.yml
+++ b/.github/workflows/upload_to_dockerhub.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - bump-debian-version
     tags:
       - '*'
 

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,5 +1,5 @@
 # Use the latest Debian image
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 # Set environment variables to avoid interactive prompts during package installation
 ENV DEBIAN_FRONTEND=noninteractive

--- a/python/extpar_cru_to_buffer.py
+++ b/python/extpar_cru_to_buffer.py
@@ -210,7 +210,7 @@ else:
                  f'extract HSURF from {raw_data_tclim_fine} '
                  f'--> {step2_cdo}')
 
-    utils.launch_shell('cdo', lock, '-f', 'nc4', '-P', omp, '-selname,HSURF,',
+    utils.launch_shell('cdo', lock, '-f', 'nc4', '-P', omp, '-selname,HSURF',
                        raw_data_tclim_fine, step2_cdo)
 
     logging.info('STEP 3: '

--- a/python/extpar_emiss_to_buffer.py
+++ b/python/extpar_emiss_to_buffer.py
@@ -201,9 +201,10 @@ emiss_max = np.amax(np.reshape(emiss_nc.variables[var][:, :],
 emiss_mrat = np.empty((12, ke_tot, je_tot, ie_tot), dtype=mrat_meta.type)
 
 for t in np.arange(12):
-    emiss_mrat[t, :, :, :] = np.divide(emiss[t, :, :, :],
-                                       emiss_max[:, :, :],
-                                       where=emiss_max[:, :, :] != 0.0)
+    np.divide(emiss[t, :, :, :],
+              emiss_max[:, :, :],
+              out=emiss_mrat[t, :, :, :],
+              where=emiss_max[:, :, :] != 0.0)
     emiss_mrat[t, :, :, :] = np.where(emiss_max[:, :, :] <= 0.0, -1.0,
                                       emiss_mrat[t, :, :, :])
 

--- a/python/extpar_ndvi_to_buffer.py
+++ b/python/extpar_ndvi_to_buffer.py
@@ -173,9 +173,10 @@ ndvi_max = np.amax(np.reshape(ndvi_nc.variables['ndvi'][:, :],
 ndvi_mrat = np.empty((12, ke_tot, je_tot, ie_tot), dtype=mrat_meta.type)
 
 for t in np.arange(12):
-    ndvi_mrat[t, :, :, :] = np.divide(ndvi[t, :, :, :],
-                                      ndvi_max[:, :, :],
-                                      where=ndvi_max[:, :, :] != 0.0)
+    np.divide(ndvi[t, :, :, :],
+              ndvi_max[:, :, :],
+              out=ndvi_mrat[t, :, :, :],
+              where=ndvi_max[:, :, :] != 0.0)
     ndvi_mrat[t, :, :, :] = np.where(ndvi_max[:, :, :] <= 0.0, -1.0,
                                      ndvi_mrat[t, :, :, :])
 


### PR DESCRIPTION
## Description

To be able to install CDO 2.5.1 from APT we need to update the Debian version in the base container from bookworm-slim to trixie-slim.

## Workflow for merging PRs

Please read these instructions carefully and follow the steps below before requesting a review by the maintainers. This way we can ensure a smoother review process and your changes will be merged sooner.

Additionally, if this is the first PR you open in EXTPAR make sure to read the [*"Information for EXTPAR Developers"*](https://c2sm.github.io/extpar/development/) section in the documentation.

### Checklist

- [ ] Provide a detailed description of your changes in the "Description" section above.
- [ ] If you implemented a new feature:
  - [ ] Document it in the correct Markdown file(s) under the [`docs/`](https://github.com/C2SM/extpar/tree/master/docs) directory.
  - [ ] [Add a new test](https://c2sm.github.io/extpar/testing/#add-a-new-test) or make sure your changes are already tested.
- [ ] Your code follows the [style guidelines](https://c2sm.github.io/extpar/development/#coding-rules-and-best-practices).
- [ ] Your changes only touch the files/lines relevant for you.
- [ ] All four required checks pass (see [*"Testing and debugging"*](#testing-and-debugging) for more details).
- [ ] No conflicts with the base branch.

If all the points above are satisfied you can ask for a review by selecting `stelliom` as a reviewer.

For any questions please ping `@stelliom` on this PR.

### Testing and debugging

The most important test for PRs is the one labeled *"EXTPAR Testsuite on Jenkins"*. This checks that the results of all testcases (described by the namelists in [`test/testsuite/data`](https://github.com/C2SM/extpar/tree/master/test/testsuite/data)) did not change compared to the references.

You can launch the testsuite by writing `launch jenkins` as a comment in the PR that you want to test. Once completed, the result of the testsuite will be shown on the PR (failure or success).

If you need more details on the testsuite results (e.g., if you are trying to debug an error or you are simply unsure why the tests fail) you can launch the testsuite with `launch jenkins(debug)`. This will run the tests as usual, but, once completed, you will be given a URL (via a comment on the PR) to access the logfiles and namelists of all tests that were run.
