### PR TITLE
Make l_terra_urb selectable in Python wrapper

### DIFF
--- a/python/WrapExtpar.py
+++ b/python/WrapExtpar.py
@@ -511,11 +511,15 @@ def setup_lu_namelist(args):
     namelist['ilookup_table_lu'] = args['ilookup_table_lu']
     namelist['raw_data_lu_path'] = args['raw_data_path']
     namelist['raw_data_glcc_path'] = args['raw_data_path']
-    namelist['l_terra_urb'] = args['l_terra_urb']
     namelist['lu_buffer_file'] = 'lu_buffer.nc'
     namelist['raw_data_glcc_filename'] = 'GLCC_usgs_class_byte.nc'
     namelist['glcc_buffer_file'] = 'glcc_buffer.nc'
     namelist['ntiles_globcover'] = 6
+
+    if args['l_terra_urb']:
+        namelist['l_terra_urb'] = ".TRUE."
+    else:
+        namelist['l_terra_urb'] = ".FALSE."
 
     if args['l_use_corine']:
         namelist['l_use_corine'] = ".TRUE."

--- a/python/WrapExtpar.py
+++ b/python/WrapExtpar.py
@@ -82,6 +82,7 @@ def main():
     lsgsl = config.get('lsgsl', False)
     lfilter_oro = config.get('lfilter_oro', False)
     lurban = config.get('lurban', False)
+    l_terra_urb = config.get('l_terra_urb', False)
     l_use_corine = config.get('l_use_corine', False)
     lradtopo = config.get('lradtopo', False)
     nhori = config.get('nhori', 24)
@@ -95,7 +96,8 @@ def main():
         ilookup_table_lu, enable_cdnc, enable_edgar, enable_art,
         use_array_cache, nhori, radtopo_radius, tcorr_lapse_rate, tcorr_offset,
         args.raw_data_path, args.run_dir, args.account, args.host,
-        args.no_batch_job, lurban, lsgsl, lfilter_oro, l_use_corine, lradtopo)
+        args.no_batch_job, lurban, l_terra_urb, lsgsl, lfilter_oro,
+        l_use_corine, lradtopo)
 
 
 def generate_external_parameters(igrid_type,
@@ -124,6 +126,7 @@ def generate_external_parameters(igrid_type,
                                  host,
                                  no_batch_job=False,
                                  lurban=False,
+                                 l_terra_urb=False,
                                  lsgsl=False,
                                  lfilter_oro=False,
                                  l_use_corine=False,
@@ -163,6 +166,7 @@ def generate_external_parameters(igrid_type,
         'lsgsl': lsgsl,
         'lfilter_oro': lfilter_oro,
         'lurban': lurban,
+        'l_terra_urb': l_terra_urb,
         'raw_data_path': raw_data_path,
         'run_dir': run_dir,
         'account': account,
@@ -507,11 +511,11 @@ def setup_lu_namelist(args):
     namelist['ilookup_table_lu'] = args['ilookup_table_lu']
     namelist['raw_data_lu_path'] = args['raw_data_path']
     namelist['raw_data_glcc_path'] = args['raw_data_path']
+    namelist['l_terra_urb'] = args['l_terra_urb']
     namelist['lu_buffer_file'] = 'lu_buffer.nc'
     namelist['raw_data_glcc_filename'] = 'GLCC_usgs_class_byte.nc'
     namelist['glcc_buffer_file'] = 'glcc_buffer.nc'
     namelist['ntiles_globcover'] = 6
-    namelist['l_terra_urb'] = ".FALSE."
 
     if args['l_use_corine']:
         namelist['l_use_corine'] = ".TRUE."
@@ -532,7 +536,6 @@ def setup_lu_namelist(args):
     elif args['ilu_type'] == 6:
         # we need "" padding for correct replacement in Fortran namelist
         namelist['raw_data_lu_filename'] = "'ECOCLIMAP_SG.nc'"
-        namelist['l_terra_urb'] = ".TRUE."
     else:
         logging.error(f'Unknown ilu_type {args["ilu_type"]}')
         raise ValueError(f'Unknown ilu_type {args["ilu_type"]}')

--- a/python/WrapExtpar.py
+++ b/python/WrapExtpar.py
@@ -516,7 +516,7 @@ def setup_lu_namelist(args):
     namelist['glcc_buffer_file'] = 'glcc_buffer.nc'
     namelist['ntiles_globcover'] = 6
 
-    if args['l_terra_urb']:
+    if args['l_terra_urb'] and args['ilu_type'] == 6:
         namelist['l_terra_urb'] = ".TRUE."
     else:
         namelist['l_terra_urb'] = ".FALSE."

--- a/test/pytest/test_wrap_extpar.py
+++ b/test/pytest/test_wrap_extpar.py
@@ -249,7 +249,8 @@ def test_setup_lu_namelist_type_1():
         'ilu_type': 1,
         'raw_data_path': '/path/to/data',
         'l_use_corine': False,
-        'ilookup_table_lu': 1
+        'ilookup_table_lu': 1,
+        'l_terra_urb': False
     }
     expected_namelist = {
         'i_landuse_data':
@@ -286,7 +287,8 @@ def test_setup_lu_namelist_corine():
         'ilu_type': 1,
         'raw_data_path': '/path/to/data',
         'l_use_corine': True,
-        'ilookup_table_lu': 1
+        'ilookup_table_lu': 1,
+        'l_terra_urb': False
     }
     expected_namelist = {
         'i_landuse_data': 1,
@@ -309,7 +311,8 @@ def test_setup_lu_namelist_type_2():
         'ilu_type': 2,
         'raw_data_path': '/path/to/data',
         'l_use_corine': False,
-        'ilookup_table_lu': 2
+        'ilookup_table_lu': 2,
+        'l_terra_urb': False
     }
     expected_namelist = {
         'i_landuse_data': 2,
@@ -332,7 +335,8 @@ def test_setup_lu_namelist_type_6():
         'ilu_type': 6,
         'raw_data_path': '/path/to/data',
         'l_use_corine': False,
-        'ilookup_table_lu': 1
+        'ilookup_table_lu': 1,
+        'l_terra_urb': True
     }
     expected_namelist = {
         'i_landuse_data': 6,
@@ -1035,6 +1039,7 @@ def test_all_placeholders_replaced_cosmo(tmp_dir):
         "host": 'docker',
         "no_batch_job": True,
         "lurban": False,
+        "l_terra_urb": False,
         "lsgsl": False,
         "lfilter_oro": False,
         "l_use_corine": False,
@@ -1077,6 +1082,7 @@ def test_all_placeholders_replaced_icon(tmp_dir, icon_grid):
         "host": 'docker',
         "no_batch_job": True,
         "lurban": False,
+        "l_terra_urb": False,
         "lsgsl": False,
         "lfilter_oro": False,
         "l_use_corine": False,


### PR DESCRIPTION
## Description

This makes the `l_terra_urb` variable selectable from the Python wrapper. This is required for the `l_terra_urb` toggle on Zonda.

## Workflow for merging PRs

Please read these instructions carefully and follow the steps below before requesting a review by the maintainers. This way we can ensure a smoother review process and your changes will be merged sooner.

Additionally, if this is the first PR you open in EXTPAR make sure to read the [*"Information for EXTPAR Developers"*](https://c2sm.github.io/extpar/development/) section in the documentation.

### Checklist

- [x] Provide a detailed description of your changes in the "Description" section above.
- [x] If you implemented a new feature:
  - [x] Document it in the correct Markdown file(s) under the [`docs/`](https://github.com/C2SM/extpar/tree/master/docs) directory.
  - [x] [Add a new test](https://c2sm.github.io/extpar/testing/#add-a-new-test) or make sure your changes are already tested.
- [x] Your code follows the [style guidelines](https://c2sm.github.io/extpar/development/#coding-rules-and-best-practices).
- [x] Your changes only touch the files/lines relevant for you.
- [x] All four required checks pass (see [*"Testing and debugging"*](#testing-and-debugging) for more details).
- [x] No conflicts with the base branch.

If all the points above are satisfied you can ask for a review by selecting `stelliom` as a reviewer.

For any questions please ping `@stelliom` on this PR.

### Testing and debugging

The most important test for PRs is the one labeled *"EXTPAR Testsuite on Jenkins"*. This checks that the results of all testcases (described by the namelists in [`test/testsuite/data`](https://github.com/C2SM/extpar/tree/master/test/testsuite/data)) did not change compared to the references.

You can launch the testsuite by writing `launch jenkins` as a comment in the PR that you want to test. Once completed, the result of the testsuite will be shown on the PR (failure or success).

If you need more details on the testsuite results (e.g., if you are trying to debug an error or you are simply unsure why the tests fail) you can launch the testsuite with `launch jenkins(debug)`. This will run the tests as usual, but, once completed, you will be given a URL (via a comment on the PR) to access the logfiles and namelists of all tests that were run.
