### PR TITLE
Add option to use infilled CORINE

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -57,6 +57,7 @@ _1. EXTPAR settings as JSON, see official docs_
     "lfilter_oro": false,
     "lurban": false,
     "l_use_corine": false,
+    "infill_corine": false,
     "lradtopo": true,
     "nhori": 24,
     "radtopo_radius": 40000

--- a/docs/user_manual/user_manual_03_fortran_modules.md
+++ b/docs/user_manual/user_manual_03_fortran_modules.md
@@ -386,9 +386,12 @@ switch (*i_landuse_data*) that gives the possibility to choose between
 the five different raw data sets e.g., 1 (Globcover), 2 (GLC2000), 3
 (GLCC), 5 (ESA CCI-LC), and 6 (Ecoclimap-SG). For Globcover one can
 additionally choose to use the corine landuse dataset by setting the
-logical switch (*l_use_corine*) to TRUE. Furthermore the path and the
-filename of the desired raw data and of GLCC are specified there. The
-user must adjust the filename and path manually according to the chosen
+logical switch (*l_use_corine*) to TRUE. Users can select between the
+official CORINE dataset (*CORINE_globcover.nc*) and a custom one
+(*CORINE_globcover_void_filled.nc*) where the voids in the dataset are
+infilled with GlobCover data. Furthermore the path and the filename of
+the desired raw data and of GLCC are specified there. The user must adjust
+the filename and path manually according to the chosen
 raw data in *i_landuse_data*. In addition the name of the desired
 lookup table is read, which again can be chosen by the user using an
 integer switch *ilookup_table_lu*. The lookup tables are described in
@@ -737,6 +740,7 @@ LCZ look-up tables are based on the values published in
 -   data input:
     - GLC2000_byte.nc, GLCC_usgs_class_byte.nc
     - CORINE_globcover.nc
+    - CORINE_globcover_void_filled.nc
     - GLOBCOVER_0_16bit.nc - GLOBCOVER_5_16bit.nc
     - ECCI_300m_0.nc - ECCI_300m_5.nc
     - ECOCLIMAP_SG.nc

--- a/python/WrapExtpar.py
+++ b/python/WrapExtpar.py
@@ -84,6 +84,7 @@ def main():
     lurban = config.get('lurban', False)
     l_terra_urb = config.get('l_terra_urb', False)
     l_use_corine = config.get('l_use_corine', False)
+    infill_corine = config.get('infill_corine', False)
     lradtopo = config.get('lradtopo', False)
     nhori = config.get('nhori', 24)
     radtopo_radius = config.get('radtopo_radius', 40000.0)
@@ -97,7 +98,7 @@ def main():
         use_array_cache, nhori, radtopo_radius, tcorr_lapse_rate, tcorr_offset,
         args.raw_data_path, args.run_dir, args.account, args.host,
         args.no_batch_job, lurban, l_terra_urb, lsgsl, lfilter_oro,
-        l_use_corine, lradtopo)
+        l_use_corine, infill_corine, lradtopo)
 
 
 def generate_external_parameters(igrid_type,
@@ -130,6 +131,7 @@ def generate_external_parameters(igrid_type,
                                  lsgsl=False,
                                  lfilter_oro=False,
                                  l_use_corine=False,
+                                 infill_corine=False,
                                  lradtopo=False):
 
     # initialize logger
@@ -158,6 +160,7 @@ def generate_external_parameters(igrid_type,
         'enable_art': enable_art,
         'use_array_cache': use_array_cache,
         'l_use_corine': l_use_corine,
+        'infill_corine': infill_corine,
         'lradtopo': lradtopo,
         'nhori': nhori,
         'radtopo_radius': radtopo_radius,
@@ -528,7 +531,10 @@ def setup_lu_namelist(args):
 
     if args['ilu_type'] == 1:
         if args['l_use_corine']:
-            namelist['raw_data_lu_filename'] = "'CORINE_globcover.nc'"
+            if args['infill_corine']:
+                namelist['raw_data_lu_filename'] = "'CORINE_globcover_void_filled.nc'" 
+            else:
+                namelist['raw_data_lu_filename'] = "'CORINE_globcover.nc'" 
             namelist['ntiles_globcover'] = 1
         else:
             namelist['raw_data_lu_filename'] = [

--- a/python/WrapExtpar.py
+++ b/python/WrapExtpar.py
@@ -532,9 +532,10 @@ def setup_lu_namelist(args):
     if args['ilu_type'] == 1:
         if args['l_use_corine']:
             if args['infill_corine']:
-                namelist['raw_data_lu_filename'] = "'CORINE_globcover_void_filled.nc'" 
+                namelist[
+                    'raw_data_lu_filename'] = "'CORINE_globcover_void_filled.nc'"
             else:
-                namelist['raw_data_lu_filename'] = "'CORINE_globcover.nc'" 
+                namelist['raw_data_lu_filename'] = "'CORINE_globcover.nc'"
             namelist['ntiles_globcover'] = 1
         else:
             namelist['raw_data_lu_filename'] = [

--- a/test/pytest/test_wrap_extpar.py
+++ b/test/pytest/test_wrap_extpar.py
@@ -282,7 +282,7 @@ def test_setup_lu_namelist_type_1():
     assert setup_lu_namelist(args) == expected_namelist
 
 
-def test_setup_lu_namelist_corine():
+def test_setup_lu_namelist_corine_1():
     args = {
         'ilu_type': 1,
         'raw_data_path': '/path/to/data',
@@ -302,6 +302,31 @@ def test_setup_lu_namelist_corine():
         'l_terra_urb': ".FALSE.",
         'l_use_corine': ".TRUE.",
         'raw_data_lu_filename': "'CORINE_globcover.nc'"
+    }
+    assert setup_lu_namelist(args) == expected_namelist
+
+
+def test_setup_lu_namelist_corine_2():
+    args = {
+        'ilu_type': 1,
+        'raw_data_path': '/path/to/data',
+        'l_use_corine': True,
+        'infill_corine': True,
+        'ilookup_table_lu': 1,
+        'l_terra_urb': False
+    }
+    expected_namelist = {
+        'i_landuse_data': 1,
+        'ilookup_table_lu': 1,
+        'raw_data_lu_path': '/path/to/data',
+        'raw_data_glcc_path': '/path/to/data',
+        'lu_buffer_file': 'lu_buffer.nc',
+        'raw_data_glcc_filename': 'GLCC_usgs_class_byte.nc',
+        'glcc_buffer_file': 'glcc_buffer.nc',
+        'ntiles_globcover': 1,
+        'l_terra_urb': ".FALSE.",
+        'l_use_corine': ".TRUE.",
+        'raw_data_lu_filename': "'CORINE_globcover_void_filled.nc'"
     }
     assert setup_lu_namelist(args) == expected_namelist
 

--- a/test/pytest/test_wrap_extpar.py
+++ b/test/pytest/test_wrap_extpar.py
@@ -287,6 +287,7 @@ def test_setup_lu_namelist_corine_1():
         'ilu_type': 1,
         'raw_data_path': '/path/to/data',
         'l_use_corine': True,
+        'infill_corine': False,
         'ilookup_table_lu': 1,
         'l_terra_urb': False
     }

--- a/test/testsuite/data/get_data.sh
+++ b/test/testsuite/data/get_data.sh
@@ -19,7 +19,7 @@ cd -
 
 test -d mch || exit 1
 cd mch/c1_aster
-wget --quiet 'ftp://iacftp.ethz.ch/pub_read/stelliom/external_parameter_mch_c1_PR444.nc'
+wget --quiet 'ftp://iacftp.ethz.ch/pub_read/stelliom/external_parameter_mch_c1_PR447.nc'
 cd -
 
 # clm
@@ -54,14 +54,14 @@ cd mpim/icon_r2b4
 wget --quiet 'http://icon-downloads.mpimet.mpg.de/grids/public/mpim/0013/icon_grid_0013_R02B04_G.nc'
 wget --quiet 'ftp://iacftp.ethz.ch/pub_read/stelliom/clim_t2m_icon_r2b4.nc'
 wget --quiet 'ftp://iacftp.ethz.ch/pub_read/stelliom/clim_tsea_icon_r2b4.nc'
-wget --quiet 'ftp://iacftp.ethz.ch/pub_read/stelliom/external_parameter_icon_mpim_PR420.nc'
+wget --quiet 'ftp://iacftp.ethz.ch/pub_read/stelliom/external_parameter_icon_mpim_PR447.nc'
 cd -
 
 # ecmwf
 test -d ecmwf || exit 1
 cd ecmwf/corine_icon
 wget --quiet 'ftp://iacftp.ethz.ch/pub_read/stelliom/corine/icon_grid_0099_R19B10.nc'
-wget --quiet 'ftp://iacftp.ethz.ch/pub_read/stelliom/corine/external_parameter_icon_corine_PR444.nc'
+wget --quiet 'ftp://iacftp.ethz.ch/pub_read/stelliom/corine/external_parameter_icon_corine_PR447.nc'
 wget --quiet 'ftp://iacftp.ethz.ch/pub_read/stelliom/corine/clim_tsea_corine.nc'
 wget --quiet 'ftp://iacftp.ethz.ch/pub_read/stelliom/corine/clim_t2m_corine.nc'
 cd -


### PR DESCRIPTION
## Description

This PR adds an option (i.e., `infill_corine`) to the Python wrapper to let Zonda users select between the normal CORINE dataset and the new CORINE dataset with infilled voids (using GlobCover data).

## Workflow for merging PRs

Please read these instructions carefully and follow the steps below before requesting a review by the maintainers. This way we can ensure a smoother review process and your changes will be merged sooner.

Additionally, if this is the first PR you open in EXTPAR make sure to read the [*"Information for EXTPAR Developers"*](https://c2sm.github.io/extpar/development/) section in the documentation.

### Checklist

- [x] Provide a detailed description of your changes in the "Description" section above.
- [x] If you implemented a new feature:
  - [x] Document it in the correct Markdown file(s) under the [`docs/`](https://github.com/C2SM/extpar/tree/master/docs) directory.
  - [x] [Add a new test](https://c2sm.github.io/extpar/testing/#add-a-new-test) or make sure your changes are already tested.
- [x] Your code follows the [style guidelines](https://c2sm.github.io/extpar/development/#coding-rules-and-best-practices).
- [x] Your changes only touch the files/lines relevant for you.
- [x] All four required checks pass (see [*"Testing and debugging"*](#testing-and-debugging) for more details).
- [x] No conflicts with the base branch.

If all the points above are satisfied you can ask for a review by selecting `stelliom` as a reviewer.

For any questions please ping `@stelliom` on this PR.

### Testing and debugging

The most important test for PRs is the one labeled *"EXTPAR Testsuite on Jenkins"*. This checks that the results of all testcases (described by the namelists in [`test/testsuite/data`](https://github.com/C2SM/extpar/tree/master/test/testsuite/data)) did not change compared to the references.

You can launch the testsuite by writing `launch jenkins` as a comment in the PR that you want to test. Once completed, the result of the testsuite will be shown on the PR (failure or success).

If you need more details on the testsuite results (e.g., if you are trying to debug an error or you are simply unsure why the tests fail) you can launch the testsuite with `launch jenkins(debug)`. This will run the tests as usual, but, once completed, you will be given a URL (via a comment on the PR) to access the logfiles and namelists of all tests that were run.
