### PR TITLE
Remove wrong raising of exception in edgar and cdnc buffers

### DIFF
--- a/python/extpar_art_to_buffer.py
+++ b/python/extpar_art_to_buffer.py
@@ -135,8 +135,9 @@ if igrid_type == 1:
     icon_grid = utils.clean_path(path_to_grid, icon_grid)
     tg = grid_def.IconGrid(icon_grid)
 else:
-    logging.error('COSMO grid not supported')
-    raise
+    error_message = "COSMO grid not supported"
+    logging.error(error_message)
+    raise ValueError(error_message)
 
 #--------------------------------------------------------------------------
 #--------------------------------------------------------------------------

--- a/python/extpar_cdnc_to_buffer.py
+++ b/python/extpar_cdnc_to_buffer.py
@@ -87,7 +87,8 @@ if (igrid_type == 1):
     grid = tg.reduce_grid(reduced_grid)
 
 elif (igrid_type == 2):
-    raise exception("cdnc data only works with ICON")
+    logging.error("cdnc data only works with ICON")
+    raise
 
 cdnc_type = utils.check_cdnctype(icdnc['icdnc_type'])
 

--- a/python/extpar_cdnc_to_buffer.py
+++ b/python/extpar_cdnc_to_buffer.py
@@ -87,8 +87,9 @@ if (igrid_type == 1):
     grid = tg.reduce_grid(reduced_grid)
 
 elif (igrid_type == 2):
-    logging.error("cdnc data only works with ICON")
-    raise
+    error_message = "CDNC data only works with ICON"
+    logging.error(error_message)
+    raise ValueError(error_message)
 
 cdnc_type = utils.check_cdnctype(icdnc['icdnc_type'])
 

--- a/python/extpar_edgar_to_buffer.py
+++ b/python/extpar_edgar_to_buffer.py
@@ -93,7 +93,8 @@ if (igrid_type == 1):
     grid = tg.reduce_grid(reduced_grid)
 
 elif (igrid_type == 2):
-    raise exception("EDGAR emission data only works with ICON")
+    logging.error("EDGAR emission data only works with ICON")
+    raise
 
 raw_data_edgar_bc = utils.clean_path(iedgar['raw_data_edgar_path'],
                                      iedgar['raw_data_edgar_filename_bc'])

--- a/python/extpar_edgar_to_buffer.py
+++ b/python/extpar_edgar_to_buffer.py
@@ -93,8 +93,9 @@ if (igrid_type == 1):
     grid = tg.reduce_grid(reduced_grid)
 
 elif (igrid_type == 2):
-    logging.error("EDGAR emission data only works with ICON")
-    raise
+    error_message = "EDGAR emission data only works with ICON"
+    logging.error(error_message)
+    raise ValueError(error_message)
 
 raw_data_edgar_bc = utils.clean_path(iedgar['raw_data_edgar_path'],
                                      iedgar['raw_data_edgar_filename_bc'])


### PR DESCRIPTION
## Description

This fixes a wrong way of raising an exception in the edgar, cdnc and art buffers that was spreading via copy&paste.

## Workflow for merging PRs

Please read these instructions carefully and follow the steps below before requesting a review by the maintainers. This way we can ensure a smoother review process and your changes will be merged sooner.

Additionally, if this is the first PR you open in EXTPAR make sure to read the [*"Information for EXTPAR Developers"*](https://c2sm.github.io/extpar/development/) section in the documentation.

### Checklist

- [ ] Provide a detailed description of your changes in the "Description" section above.
- [ ] If you implemented a new feature:
  - [ ] Document it in the correct Markdown file(s) under the [`docs/`](https://github.com/C2SM/extpar/tree/master/docs) directory.
  - [ ] [Add a new test](https://c2sm.github.io/extpar/testing/#add-a-new-test) or make sure your changes are already tested.
- [ ] Your code follows the [style guidelines](https://c2sm.github.io/extpar/development/#coding-rules-and-best-practices).
- [ ] Your changes only touch the files/lines relevant for you.
- [ ] All four required checks pass (see [*"Testing and debugging"*](#testing-and-debugging) for more details).
- [ ] No conflicts with the base branch.

If all the points above are satisfied you can ask for a review by selecting `stelliom` as a reviewer.

For any questions please ping `@stelliom` on this PR.

### Testing and debugging

The most important test for PRs is the one labeled *"EXTPAR Testsuite on Jenkins"*. This checks that the results of all testcases (described by the namelists in [`test/testsuite/data`](https://github.com/C2SM/extpar/tree/master/test/testsuite/data)) did not change compared to the references.

You can launch the testsuite by writing `launch jenkins` as a comment in the PR that you want to test. Once completed, the result of the testsuite will be shown on the PR (failure or success).

If you need more details on the testsuite results (e.g., if you are trying to debug an error or you are simply unsure why the tests fail) you can launch the testsuite with `launch jenkins(debug)`. This will run the tests as usual, but, once completed, you will be given a URL (via a comment on the PR) to access the logfiles and namelists of all tests that were run.
